### PR TITLE
fix HTTP-version case-sensitivity on Response.php

### DIFF
--- a/src/Response/Response.php
+++ b/src/Response/Response.php
@@ -154,7 +154,7 @@ class Response
 
     public function __toString()
     {
-        $head = "Http/1.1 $this->status {$this->phrases[$this->status]}\r\n";
+        $head = "HTTP/1.1 $this->status {$this->phrases[$this->status]}\r\n";
 
         foreach ($this->headers as $name => $value) {
             if (\is_array($value)) {


### PR DESCRIPTION
Hi !
Based on rfc7230 : HTTP-version is case-sensitive. 
For example, wrk don't work with `Http/1.1` version but work with `HTTP/1.1`.