### PR TITLE
Fix cpu count for openswoole

### DIFF
--- a/src/Helper/fomo.php
+++ b/src/Helper/fomo.php
@@ -81,7 +81,12 @@ if (! function_exists('config')) {
 if (! function_exists('cpuCount')) {
     function cpuCount(): int
     {
-        return swoole_cpu_num();
+        if (class_exists(OpenSwoole\Util::class)) {
+            return OpenSwoole\Util::getCPUNum();
+        } else if (function_exists('swoole_cpu_num')) {
+            return swoole_cpu_num();
+        }
+        return 1;
     }
 }
 


### PR DESCRIPTION
I installed `openswoole` extension instead of `swoole`, when i run `php engineer server:start`, i received an error:

```
Fatal error: Uncaught Error: Call to undefined function swoole_cpu_num() in /path/fomoapp/vendor/fomo/framework/src/Helper/fomo.php:69
Stack trace:
#0 /path/fomoapp/config/server.php(14): cpuCount()
#1 /path/fomoapp/vendor/fomo/framework/src/Config/Config.php(28): require_once('/Users/d/Data/l...')
#2 /path/fomoapp/vendor/fomo/framework/src/Helper/fomo.php(59): Fomo\Config\Config->get('ssl.ssl_cert_fi...', NULL)
#3 /path/fomoapp/vendor/fomo/framework/src/Commands/Server/Start.php(87): config('server.ssl.ssl_...')
#4 /path/fomoapp/vendor/symfony/console/Command/Command.php(308): Fomo\Commands\Server\Start->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#5 /path/fomoapp/vendor/symfony/console/Application.php(1014): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#6 /path/fomoapp/vendor/symfony/console/Application.php(301): Symfony\Component\Console\Application->doRunCommand(Object(Fomo\Commands\Server\Start), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#7 /path/fomoapp/vendor/symfony/console/Application.php(171): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#8 /path/fomoapp/engineer(98): Symfony\Component\Console\Application->run()
#9 {main}
  thrown in /path/fomoapp/vendor/fomo/framework/src/Helper/fomo.php on line 69
```

This PR will check if openswoole, then use [`OpenSwoole\Util::getCPUNum()`](https://openswoole.com/docs/modules/swoole-util-get-cpu-num) instead.

