### PR TITLE
use serialize instead json_encode to keep data type

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -91,15 +91,15 @@ class Cache implements InstanceInterface
 
     protected function getByKey(string $key)
     {
-        return json_decode(Redis::getInstance()->get($key));
+        return unserialize(Redis::getInstance()->get($key));
     }
 
     protected function setByKey(string $key , $value , int $expire = null): void
     {
         if (is_null($expire)){
-            Redis::getInstance()->set($key , json_encode($value));
+            Redis::getInstance()->set($key , serialize($value));
         } else{
-            Redis::getInstance()->setex($key , $expire , json_encode($value));
+            Redis::getInstance()->setex($key , $expire , serialize($value));
         }
     }
 


### PR DESCRIPTION
Problem: json_decode / json_encode do not keep the data type of the variable:
example: by using `var_dump(json_decode(json_encode([ 'a' => 'a', 'b' => 1])));`, the result is:
```
object(stdClass)#243 (2) {
  ["a"]=>
  string(1) "a"
  ["b"]=>
  int(1)
}
```

If we use `var_dump(unserialize(serialize([ 'a' => 'a', 'b' => 1])));` we will got the original data:
```
array(2) {
  ["a"]=>
  string(1) "a"
  ["b"]=>
  int(1)
}
```